### PR TITLE
amqp: allow to configure heartbeats

### DIFF
--- a/src/Queue/Broker/AMQP.php
+++ b/src/Queue/Broker/AMQP.php
@@ -38,7 +38,8 @@ class AMQP implements Publisher, Consumer
         private readonly int $httpPort = 15672,
         private readonly ?string $user = null,
         private readonly ?string $password = null,
-        private readonly string $vhost = '/'
+        private readonly string $vhost = '/',
+        private readonly int $heartbeat = 0,
     ) {
     }
 
@@ -177,7 +178,7 @@ class AMQP implements Publisher, Consumer
     private function withChannel(callable $callback): void
     {
         $createChannel = function (): AMQPChannel {
-            $connection = new AMQPStreamConnection($this->host, $this->port, $this->user, $this->password, $this->vhost);
+            $connection = new AMQPStreamConnection($this->host, $this->port, $this->user, $this->password, $this->vhost, heartbeat: $this->heartbeat);
             if (is_callable($this->connectionConfigHook)) {
                 call_user_func($this->connectionConfigHook, $connection);
             }


### PR DESCRIPTION
Allows to configure AMQP heartbeats: https://www.rabbitmq.com/docs/heartbeats

When using heartbeat the client needs to periodically call `checkHeartBeat`, for example:

```
$amqp = new Queue\Broker\AMQP(heartbeat: 300);
$amqp->configureConnection(function (AbstractConnection $connection) {
  Timer::tick(10_000, fn () => $connection->checkHeartBeat());
});
```