### PR TITLE
feat: add workerStop handling

### DIFF
--- a/src/Queue/Adapter/Swoole.php
+++ b/src/Queue/Adapter/Swoole.php
@@ -2,6 +2,7 @@
 
 namespace Utopia\Queue\Adapter;
 
+use Swoole\Constant;
 use Swoole\Process\Pool;
 use Utopia\Queue\Adapter;
 use Utopia\Queue\Consumer;
@@ -9,6 +10,9 @@ use Utopia\Queue\Consumer;
 class Swoole extends Adapter
 {
     protected Pool $pool;
+
+    /** @var callable */
+    private $onStop;
 
     public function __construct(Consumer $consumer, int $workerNum, string $queue, string $namespace = 'utopia-queue')
     {
@@ -27,13 +31,16 @@ class Swoole extends Adapter
 
     public function stop(): self
     {
+        if ($this->onStop) {
+            call_user_func($this->onStop);
+        }
         $this->pool->shutdown();
         return $this;
     }
 
     public function workerStart(callable $callback): self
     {
-        $this->pool->on('WorkerStart', function (Pool $pool, string $workerId) use ($callback) {
+        $this->pool->on(Constant::EVENT_WORKER_START, function (Pool $pool, string $workerId) use ($callback) {
             call_user_func($callback, $workerId);
         });
 
@@ -42,7 +49,8 @@ class Swoole extends Adapter
 
     public function workerStop(callable $callback): self
     {
-        $this->pool->on('WorkerStart', function (Pool $pool, string $workerId) use ($callback) {
+        $this->onStop = $callback;
+        $this->pool->on(Constant::EVENT_WORKER_STOP, function (Pool $pool, string $workerId) use ($callback) {
             call_user_func($callback, $workerId);
         });
 

--- a/src/Queue/Broker/AMQP.php
+++ b/src/Queue/Broker/AMQP.php
@@ -131,6 +131,7 @@ class AMQP implements Publisher, Consumer
 
     public function close(): void
     {
+        $this->channel?->stopConsume();
         $this->channel?->getConnection()?->close();
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved shutdown reliability by ensuring stop callbacks are executed before pool shutdown and by explicitly stopping message consumption before closing connections.
- **Refactor**
	- Enhanced event handling by using standardized event constants and restructuring job processing and shutdown logic for better maintainability.
- **New Features**
	- Added support for executing custom callbacks when a worker stops.
- **Chores**
	- Removed an unused method for worker stop callbacks from the server, consolidating this functionality within the adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->