### PR TITLE
feat: add configurable connect and read timeouts to Redis connections

### DIFF
--- a/src/Queue/Connection/Redis.php
+++ b/src/Queue/Connection/Redis.php
@@ -14,6 +14,19 @@ class Redis implements Connection
     protected float $readTimeout;
     protected ?\Redis $redis = null;
 
+    /**
+     * @param string      $host           Redis host.
+     * @param int         $port           Redis port.
+     * @param string|null $user           Redis ACL username (optional).
+     * @param string|null $password       Redis password (optional).
+     * @param float       $connectTimeout Connection timeout in seconds (0 = no timeout).
+     * @param float       $readTimeout    Socket read timeout in seconds (-1 = infinite).
+     *                                    Use -1 for consumers so blocking commands (BRPOP/BLPOP)
+     *                                    are not interrupted; the per-call blockingReadTimeout()
+     *                                    helper adds a safety buffer automatically.
+     *                                    Use a positive value (e.g. 5) for publishers so a hung
+     *                                    Redis fails fast rather than blocking indefinitely.
+     */
     public function __construct(string $host, int $port = 6379, ?string $user = null, ?string $password = null, float $connectTimeout = 5, float $readTimeout = -1)
     {
         $this->host = $host;

--- a/src/Queue/Connection/Redis.php
+++ b/src/Queue/Connection/Redis.php
@@ -10,14 +10,18 @@ class Redis implements Connection
     protected int $port;
     protected ?string $user;
     protected ?string $password;
+    protected float $connectTimeout;
+    protected float $readTimeout;
     protected ?\Redis $redis = null;
 
-    public function __construct(string $host, int $port = 6379, ?string $user = null, ?string $password = null)
+    public function __construct(string $host, int $port = 6379, ?string $user = null, ?string $password = null, float $connectTimeout = 5, float $readTimeout = 5)
     {
         $this->host = $host;
         $this->port = $port;
         $this->user = $user;
         $this->password = $password;
+        $this->connectTimeout = $connectTimeout;
+        $this->readTimeout = $readTimeout;
     }
 
     public function rightPopLeftPushArray(string $queue, string $destination, int $timeout): array|false
@@ -186,7 +190,8 @@ class Redis implements Connection
 
         $this->redis = new \Redis();
 
-        $this->redis->connect($this->host, $this->port);
+        $this->redis->connect($this->host, $this->port, $this->connectTimeout);
+        $this->redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->readTimeout);
 
         return $this->redis;
     }

--- a/src/Queue/Connection/Redis.php
+++ b/src/Queue/Connection/Redis.php
@@ -14,7 +14,7 @@ class Redis implements Connection
     protected float $readTimeout;
     protected ?\Redis $redis = null;
 
-    public function __construct(string $host, int $port = 6379, ?string $user = null, ?string $password = null, float $connectTimeout = 5, float $readTimeout = 5)
+    public function __construct(string $host, int $port = 6379, ?string $user = null, ?string $password = null, float $connectTimeout = 5, float $readTimeout = -1)
     {
         $this->host = $host;
         $this->port = $port;
@@ -34,9 +34,22 @@ class Redis implements Connection
 
         return json_decode($response, true);
     }
+
     public function rightPopLeftPush(string $queue, string $destination, int $timeout): string|false
     {
-        $response = $this->getRedis()->bRPopLPush($queue, $destination, $timeout);
+        $redis = $this->getRedis();
+        $prev = $redis->getOption(\Redis::OPT_READ_TIMEOUT);
+        $redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
+        try {
+            $response = $redis->bRPopLPush($queue, $destination, $timeout);
+        } catch (\RedisException $e) {
+            $this->redis = null;
+            throw $e;
+        } finally {
+            if ($this->redis) {
+                $redis->setOption(\Redis::OPT_READ_TIMEOUT, $prev);
+            }
+        }
 
         if (!$response) {
             return false;
@@ -44,6 +57,7 @@ class Redis implements Connection
 
         return $response;
     }
+
     public function rightPushArray(string $queue, array $value): bool
     {
         return !!$this->getRedis()->rPush($queue, json_encode($value));
@@ -77,7 +91,19 @@ class Redis implements Connection
 
     public function rightPop(string $queue, int $timeout): string|false
     {
-        $response = $this->getRedis()->brPop([$queue], $timeout);
+        $redis = $this->getRedis();
+        $prev = $redis->getOption(\Redis::OPT_READ_TIMEOUT);
+        $redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
+        try {
+            $response = $redis->brPop([$queue], $timeout);
+        } catch (\RedisException $e) {
+            $this->redis = null;
+            throw $e;
+        } finally {
+            if ($this->redis) {
+                $redis->setOption(\Redis::OPT_READ_TIMEOUT, $prev);
+            }
+        }
 
         if (empty($response)) {
             return false;
@@ -88,18 +114,30 @@ class Redis implements Connection
 
     public function leftPopArray(string $queue, int $timeout): array|false
     {
-        $response = $this->getRedis()->blPop($queue, $timeout);
+        $response = $this->leftPop($queue, $timeout);
 
-        if (empty($response)) {
+        if ($response === false) {
             return false;
         }
 
-        return json_decode($response[1], true) ?? false;
+        return json_decode($response, true) ?? false;
     }
 
     public function leftPop(string $queue, int $timeout): string|false
     {
-        $response = $this->getRedis()->blPop($queue, $timeout);
+        $redis = $this->getRedis();
+        $prev = $redis->getOption(\Redis::OPT_READ_TIMEOUT);
+        $redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
+        try {
+            $response = $redis->blPop($queue, $timeout);
+        } catch (\RedisException $e) {
+            $this->redis = null;
+            throw $e;
+        } finally {
+            if ($this->redis) {
+                $redis->setOption(\Redis::OPT_READ_TIMEOUT, $prev);
+            }
+        }
 
         if (empty($response)) {
             return false;
@@ -194,5 +232,23 @@ class Redis implements Connection
         $this->redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->readTimeout);
 
         return $this->redis;
+    }
+
+    /**
+     * Returns the read timeout to use for a blocking command.
+     * Ensures the socket does not time out before Redis returns.
+     * A $timeout of 0 means block indefinitely, so we use -1 (infinite).
+     */
+    private function blockingReadTimeout(int $timeout): float
+    {
+        if ($timeout <= 0) {
+            return -1;
+        }
+        // Add 1s buffer so the socket outlasts the Redis-side block timeout.
+        // Also respect an explicit readTimeout if it is already larger.
+        if ($this->readTimeout < 0) {
+            return -1;
+        }
+        return max((float)($timeout + 1), $this->readTimeout);
     }
 }

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -7,11 +7,15 @@ use Utopia\Queue\Connection;
 class RedisCluster implements Connection
 {
     protected array $seeds;
+    protected float $connectTimeout;
+    protected float $readTimeout;
     protected ?\RedisCluster $redis = null;
 
-    public function __construct(array $seeds)
+    public function __construct(array $seeds, float $connectTimeout = 5, float $readTimeout = 5)
     {
         $this->seeds = $seeds;
+        $this->connectTimeout = $connectTimeout;
+        $this->readTimeout = $readTimeout;
     }
 
     public function rightPopLeftPushArray(string $queue, string $destination, int $timeout): array|false
@@ -181,7 +185,7 @@ class RedisCluster implements Connection
             return $this->redis;
         }
 
-        $this->redis = new \RedisCluster(null, $this->seeds);
+        $this->redis = new \RedisCluster(null, $this->seeds, $this->connectTimeout, $this->readTimeout);
         return $this->redis;
     }
 }

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -6,6 +6,11 @@ use Utopia\Queue\Connection;
 
 class RedisCluster implements Connection
 {
+    // OPT_READ_TIMEOUT (3) is defined on \Redis but not on \RedisCluster in all
+    // environments (e.g. Swoole replaces RedisCluster with its own coroutine-aware
+    // class that omits the constant). The numeric value is stable across phpredis.
+    private const OPT_READ_TIMEOUT = 3;
+
     protected array $seeds;
     protected float $connectTimeout;
     protected float $readTimeout;
@@ -42,8 +47,8 @@ class RedisCluster implements Connection
     public function rightPopLeftPush(string $queue, string $destination, int $timeout): string|false
     {
         $redis = $this->getRedis();
-        $prev = $redis->getOption(\RedisCluster::OPT_READ_TIMEOUT);
-        $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
+        $prev = $redis->getOption(self::OPT_READ_TIMEOUT);
+        $redis->setOption(self::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
         try {
             $response = $redis->bRPopLPush($queue, $destination, $timeout);
         } catch (\RedisException $e) {
@@ -51,7 +56,7 @@ class RedisCluster implements Connection
             throw $e;
         } finally {
             if ($this->redis) {
-                $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $prev);
+                $redis->setOption(self::OPT_READ_TIMEOUT, $prev);
             }
         }
 
@@ -96,8 +101,8 @@ class RedisCluster implements Connection
     public function rightPop(string $queue, int $timeout): string|false
     {
         $redis = $this->getRedis();
-        $prev = $redis->getOption(\RedisCluster::OPT_READ_TIMEOUT);
-        $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
+        $prev = $redis->getOption(self::OPT_READ_TIMEOUT);
+        $redis->setOption(self::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
         try {
             $response = $redis->brPop([$queue], $timeout);
         } catch (\RedisException $e) {
@@ -105,7 +110,7 @@ class RedisCluster implements Connection
             throw $e;
         } finally {
             if ($this->redis) {
-                $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $prev);
+                $redis->setOption(self::OPT_READ_TIMEOUT, $prev);
             }
         }
 
@@ -130,8 +135,8 @@ class RedisCluster implements Connection
     public function leftPop(string $queue, int $timeout): string|false
     {
         $redis = $this->getRedis();
-        $prev = $redis->getOption(\RedisCluster::OPT_READ_TIMEOUT);
-        $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
+        $prev = $redis->getOption(self::OPT_READ_TIMEOUT);
+        $redis->setOption(self::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
         try {
             $response = $redis->blPop($queue, $timeout);
         } catch (\RedisException $e) {
@@ -139,7 +144,7 @@ class RedisCluster implements Connection
             throw $e;
         } finally {
             if ($this->redis) {
-                $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $prev);
+                $redis->setOption(self::OPT_READ_TIMEOUT, $prev);
             }
         }
 

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -11,6 +11,16 @@ class RedisCluster implements Connection
     protected float $readTimeout;
     protected ?\RedisCluster $redis = null;
 
+    /**
+     * @param array $seeds          Cluster seed nodes in "host:port" format.
+     * @param float $connectTimeout Connection timeout in seconds per node (0 = no timeout).
+     * @param float $readTimeout    Socket read timeout in seconds (-1 = infinite).
+     *                              Use -1 for consumers so blocking commands (BRPOP/BLPOP)
+     *                              are not interrupted; the per-call blockingReadTimeout()
+     *                              helper adds a safety buffer automatically.
+     *                              Use a positive value (e.g. 5) for publishers so a hung
+     *                              node fails fast rather than blocking indefinitely.
+     */
     public function __construct(array $seeds, float $connectTimeout = 5, float $readTimeout = -1)
     {
         $this->seeds = $seeds;

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -11,7 +11,7 @@ class RedisCluster implements Connection
     protected float $readTimeout;
     protected ?\RedisCluster $redis = null;
 
-    public function __construct(array $seeds, float $connectTimeout = 5, float $readTimeout = 5)
+    public function __construct(array $seeds, float $connectTimeout = 5, float $readTimeout = -1)
     {
         $this->seeds = $seeds;
         $this->connectTimeout = $connectTimeout;
@@ -28,9 +28,22 @@ class RedisCluster implements Connection
 
         return json_decode($response, true);
     }
+
     public function rightPopLeftPush(string $queue, string $destination, int $timeout): string|false
     {
-        $response = $this->getRedis()->bRPopLPush($queue, $destination, $timeout);
+        $redis = $this->getRedis();
+        $prev = $redis->getOption(\RedisCluster::OPT_READ_TIMEOUT);
+        $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
+        try {
+            $response = $redis->bRPopLPush($queue, $destination, $timeout);
+        } catch (\RedisException $e) {
+            $this->redis = null;
+            throw $e;
+        } finally {
+            if ($this->redis) {
+                $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $prev);
+            }
+        }
 
         if (!$response) {
             return false;
@@ -38,6 +51,7 @@ class RedisCluster implements Connection
 
         return $response;
     }
+
     public function rightPushArray(string $queue, array $value): bool
     {
         return !!$this->getRedis()->rPush($queue, json_encode($value));
@@ -71,7 +85,19 @@ class RedisCluster implements Connection
 
     public function rightPop(string $queue, int $timeout): string|false
     {
-        $response = $this->getRedis()->brPop([$queue], $timeout);
+        $redis = $this->getRedis();
+        $prev = $redis->getOption(\RedisCluster::OPT_READ_TIMEOUT);
+        $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
+        try {
+            $response = $redis->brPop([$queue], $timeout);
+        } catch (\RedisException $e) {
+            $this->redis = null;
+            throw $e;
+        } finally {
+            if ($this->redis) {
+                $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $prev);
+            }
+        }
 
         if (empty($response)) {
             return false;
@@ -82,18 +108,30 @@ class RedisCluster implements Connection
 
     public function leftPopArray(string $queue, int $timeout): array|false
     {
-        $response = $this->getRedis()->blPop($queue, $timeout);
+        $response = $this->leftPop($queue, $timeout);
 
-        if (empty($response)) {
+        if ($response === false) {
             return false;
         }
 
-        return json_decode($response[1], true) ?? false;
+        return json_decode($response, true) ?? false;
     }
 
     public function leftPop(string $queue, int $timeout): string|false
     {
-        $response = $this->getRedis()->blPop($queue, $timeout);
+        $redis = $this->getRedis();
+        $prev = $redis->getOption(\RedisCluster::OPT_READ_TIMEOUT);
+        $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $this->blockingReadTimeout($timeout));
+        try {
+            $response = $redis->blPop($queue, $timeout);
+        } catch (\RedisException $e) {
+            $this->redis = null;
+            throw $e;
+        } finally {
+            if ($this->redis) {
+                $redis->setOption(\RedisCluster::OPT_READ_TIMEOUT, $prev);
+            }
+        }
 
         if (empty($response)) {
             return false;
@@ -187,5 +225,23 @@ class RedisCluster implements Connection
 
         $this->redis = new \RedisCluster(null, $this->seeds, $this->connectTimeout, $this->readTimeout);
         return $this->redis;
+    }
+
+    /**
+     * Returns the read timeout to use for a blocking command.
+     * Ensures the socket does not time out before Redis returns.
+     * A $timeout of 0 means block indefinitely, so we use -1 (infinite).
+     */
+    private function blockingReadTimeout(int $timeout): float
+    {
+        if ($timeout <= 0) {
+            return -1;
+        }
+        // Add 1s buffer so the socket outlasts the Redis-side block timeout.
+        // Also respect an explicit readTimeout if it is already larger.
+        if ($this->readTimeout < 0) {
+            return -1;
+        }
+        return max((float)($timeout + 1), $this->readTimeout);
     }
 }


### PR DESCRIPTION
Queue Redis connections previously used PHP's default timeout of 0 (blocking indefinitely). When Redis becomes unresponsive due to contention (e.g. Dragonfly TxQueue saturation), worker BRPOP calls would hang until the OS TCP timeout (21-127s), causing fatal "read error on connection" crashes and cascading restarts.

Adds `connectTimeout` and `readTimeout` parameters (default 5s) to both `Redis` and `RedisCluster` connection classes so callers can configure fail-fast behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redis and Redis Cluster connections gain configurable connect and read timeouts (defaults preserved), allowing better control over connection behavior.
  * Blocking operations now honor per-call read timeouts to avoid indefinite blocking.

* **Bug Fixes**
  * Improved robustness: blocking calls restore timeouts after use and will reset connections on errors to prevent stale/locked connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->