### PR TITLE
feat(redis): survive transient Redis outages with bounded reconnects

### DIFF
--- a/src/Queue/Broker/Redis.php
+++ b/src/Queue/Broker/Redis.php
@@ -36,7 +36,11 @@ class Redis implements Publisher, Consumer
                     break;
                 }
 
-                $this->connection->close();
+                try {
+                    $this->connection->close();
+                } catch (\Throwable) {
+                }
+
                 \usleep(\mt_rand(0, $reconnectBackoffMs) * 1000);
                 $reconnectBackoffMs = \min(self::RECONNECT_MAX_BACKOFF_MS, $reconnectBackoffMs * 2);
 

--- a/src/Queue/Broker/Redis.php
+++ b/src/Queue/Broker/Redis.php
@@ -15,14 +15,26 @@ class Redis implements Publisher, Consumer
     private const int RECONNECT_MAX_BACKOFF_MS = 5_000;
 
     private bool $closed = false;
+    /**
+     * @var (callable(Queue, \Throwable, int, int): void)|null
+     */
+    private $reconnectCallback = null;
 
     public function __construct(private readonly Connection $connection)
     {
     }
 
+    public function setReconnectCallback(?callable $callback): self
+    {
+        $this->reconnectCallback = $callback;
+
+        return $this;
+    }
+
     public function consume(Queue $queue, callable $messageCallback, callable $successCallback, callable $errorCallback): void
     {
         $reconnectBackoffMs = self::RECONNECT_BACKOFF_MS;
+        $reconnectAttempt = 0;
 
         while (!$this->closed) {
             /**
@@ -31,17 +43,23 @@ class Redis implements Publisher, Consumer
             try {
                 $nextMessage = $this->connection->rightPopArray("{$queue->namespace}.queue.{$queue->name}", self::POP_TIMEOUT);
                 $reconnectBackoffMs = self::RECONNECT_BACKOFF_MS;
+                $reconnectAttempt = 0;
             } catch (\RedisException|\RedisClusterException $e) {
                 if ($this->closed) {
                     break;
                 }
+
+                $reconnectAttempt++;
 
                 try {
                     $this->connection->close();
                 } catch (\Throwable) {
                 }
 
-                \usleep(\mt_rand(0, $reconnectBackoffMs) * 1000);
+                $sleepMs = \mt_rand(0, $reconnectBackoffMs);
+                $this->triggerReconnectCallback($queue, $e, $reconnectAttempt, $sleepMs);
+
+                \usleep($sleepMs * 1000);
                 $reconnectBackoffMs = \min(self::RECONNECT_MAX_BACKOFF_MS, $reconnectBackoffMs * 2);
 
                 continue;
@@ -115,6 +133,18 @@ class Redis implements Publisher, Consumer
     public function close(): void
     {
         $this->closed = true;
+    }
+
+    private function triggerReconnectCallback(Queue $queue, \Throwable $error, int $attempt, int $sleepMs): void
+    {
+        if (!\is_callable($this->reconnectCallback)) {
+            return;
+        }
+
+        try {
+            ($this->reconnectCallback)($queue, $error, $attempt, $sleepMs);
+        } catch (\Throwable) {
+        }
     }
 
     public function enqueue(Queue $queue, array $payload, bool $priority = false): bool

--- a/src/Queue/Broker/Redis.php
+++ b/src/Queue/Broker/Redis.php
@@ -11,6 +11,9 @@ use Utopia\Queue\Queue;
 class Redis implements Publisher, Consumer
 {
     private const int POP_TIMEOUT = 2;
+    private const int RECONNECT_BASE_BACKOFF_MS = 100;
+    private const int RECONNECT_MAX_BACKOFF_MS = 5_000;
+    private const int RECONNECT_BACKOFF_CAP_SHIFT = 10;
 
     private bool $closed = false;
 
@@ -20,18 +23,34 @@ class Redis implements Publisher, Consumer
 
     public function consume(Queue $queue, callable $messageCallback, callable $successCallback, callable $errorCallback): void
     {
+        $reconnectAttempts = 0;
+
         while (!$this->closed) {
             /**
              * Waiting for next Job.
              */
             try {
                 $nextMessage = $this->connection->rightPopArray("{$queue->namespace}.queue.{$queue->name}", self::POP_TIMEOUT);
+                $reconnectAttempts = 0;
             } catch (\RedisException $e) {
                 if ($this->closed) {
                     break;
                 }
 
-                throw $e;
+                // Drop the stale connection so the next pop opens a fresh one, then
+                // back off with full jitter before retrying. Keeps the worker alive
+                // across transient Redis outages instead of crash-looping.
+                $this->connection->close();
+
+                $reconnectAttempts++;
+                $shift = \min(self::RECONNECT_BACKOFF_CAP_SHIFT, $reconnectAttempts - 1);
+                $backoffMs = \min(
+                    self::RECONNECT_MAX_BACKOFF_MS,
+                    self::RECONNECT_BASE_BACKOFF_MS * (2 ** $shift),
+                );
+                \usleep(\mt_rand(0, $backoffMs) * 1000);
+
+                continue;
             }
 
             if (!$nextMessage) {

--- a/src/Queue/Broker/Redis.php
+++ b/src/Queue/Broker/Redis.php
@@ -13,7 +13,6 @@ class Redis implements Publisher, Consumer
     private const int POP_TIMEOUT = 2;
     private const int RECONNECT_BASE_BACKOFF_MS = 100;
     private const int RECONNECT_MAX_BACKOFF_MS = 5_000;
-    private const int RECONNECT_BACKOFF_CAP_SHIFT = 10;
 
     private bool $closed = false;
 
@@ -23,7 +22,7 @@ class Redis implements Publisher, Consumer
 
     public function consume(Queue $queue, callable $messageCallback, callable $successCallback, callable $errorCallback): void
     {
-        $reconnectAttempts = 0;
+        $reconnectBackoffMs = self::RECONNECT_BASE_BACKOFF_MS;
 
         while (!$this->closed) {
             /**
@@ -31,24 +30,15 @@ class Redis implements Publisher, Consumer
              */
             try {
                 $nextMessage = $this->connection->rightPopArray("{$queue->namespace}.queue.{$queue->name}", self::POP_TIMEOUT);
-                $reconnectAttempts = 0;
-            } catch (\RedisException $e) {
+                $reconnectBackoffMs = self::RECONNECT_BASE_BACKOFF_MS;
+            } catch (\RedisException|\RedisClusterException $e) {
                 if ($this->closed) {
                     break;
                 }
 
-                // Drop the stale connection so the next pop opens a fresh one, then
-                // back off with full jitter before retrying. Keeps the worker alive
-                // across transient Redis outages instead of crash-looping.
                 $this->connection->close();
-
-                $reconnectAttempts++;
-                $shift = \min(self::RECONNECT_BACKOFF_CAP_SHIFT, $reconnectAttempts - 1);
-                $backoffMs = \min(
-                    self::RECONNECT_MAX_BACKOFF_MS,
-                    self::RECONNECT_BASE_BACKOFF_MS * (2 ** $shift),
-                );
-                \usleep(\mt_rand(0, $backoffMs) * 1000);
+                \usleep(\mt_rand(0, $reconnectBackoffMs) * 1000);
+                $reconnectBackoffMs = \min(self::RECONNECT_MAX_BACKOFF_MS, $reconnectBackoffMs * 2);
 
                 continue;
             }

--- a/src/Queue/Broker/Redis.php
+++ b/src/Queue/Broker/Redis.php
@@ -19,6 +19,10 @@ class Redis implements Publisher, Consumer
      * @var (callable(Queue, \Throwable, int, int): void)|null
      */
     private $reconnectCallback = null;
+    /**
+     * @var (callable(Queue, int): void)|null
+     */
+    private $reconnectSuccessCallback = null;
 
     public function __construct(private readonly Connection $connection)
     {
@@ -27,6 +31,13 @@ class Redis implements Publisher, Consumer
     public function setReconnectCallback(?callable $callback): self
     {
         $this->reconnectCallback = $callback;
+
+        return $this;
+    }
+
+    public function setReconnectSuccessCallback(?callable $callback): self
+    {
+        $this->reconnectSuccessCallback = $callback;
 
         return $this;
     }
@@ -42,6 +53,10 @@ class Redis implements Publisher, Consumer
              */
             try {
                 $nextMessage = $this->connection->rightPopArray("{$queue->namespace}.queue.{$queue->name}", self::POP_TIMEOUT);
+                if ($reconnectAttempt > 0) {
+                    $this->triggerReconnectSuccessCallback($queue, $reconnectAttempt);
+                }
+
                 $reconnectBackoffMs = self::RECONNECT_BACKOFF_MS;
                 $reconnectAttempt = 0;
             } catch (\RedisException|\RedisClusterException $e) {
@@ -143,6 +158,18 @@ class Redis implements Publisher, Consumer
 
         try {
             ($this->reconnectCallback)($queue, $error, $attempt, $sleepMs);
+        } catch (\Throwable) {
+        }
+    }
+
+    private function triggerReconnectSuccessCallback(Queue $queue, int $attempts): void
+    {
+        if (!\is_callable($this->reconnectSuccessCallback)) {
+            return;
+        }
+
+        try {
+            ($this->reconnectSuccessCallback)($queue, $attempts);
         } catch (\Throwable) {
         }
     }

--- a/src/Queue/Broker/Redis.php
+++ b/src/Queue/Broker/Redis.php
@@ -11,7 +11,7 @@ use Utopia\Queue\Queue;
 class Redis implements Publisher, Consumer
 {
     private const int POP_TIMEOUT = 2;
-    private const int RECONNECT_BASE_BACKOFF_MS = 100;
+    private const int RECONNECT_BACKOFF_MS = 100;
     private const int RECONNECT_MAX_BACKOFF_MS = 5_000;
 
     private bool $closed = false;
@@ -22,7 +22,7 @@ class Redis implements Publisher, Consumer
 
     public function consume(Queue $queue, callable $messageCallback, callable $successCallback, callable $errorCallback): void
     {
-        $reconnectBackoffMs = self::RECONNECT_BASE_BACKOFF_MS;
+        $reconnectBackoffMs = self::RECONNECT_BACKOFF_MS;
 
         while (!$this->closed) {
             /**
@@ -30,7 +30,7 @@ class Redis implements Publisher, Consumer
              */
             try {
                 $nextMessage = $this->connection->rightPopArray("{$queue->namespace}.queue.{$queue->name}", self::POP_TIMEOUT);
-                $reconnectBackoffMs = self::RECONNECT_BASE_BACKOFF_MS;
+                $reconnectBackoffMs = self::RECONNECT_BACKOFF_MS;
             } catch (\RedisException|\RedisClusterException $e) {
                 if ($this->closed) {
                     break;

--- a/src/Queue/Connection/Redis.php
+++ b/src/Queue/Connection/Redis.php
@@ -7,7 +7,7 @@ use Utopia\Queue\Connection;
 class Redis implements Connection
 {
     protected const int CONNECT_MAX_ATTEMPTS = 5;
-    protected const int CONNECT_BASE_BACKOFF_MS = 100;
+    protected const int CONNECT_BACKOFF_MS = 100;
     protected const int CONNECT_MAX_BACKOFF_MS = 3_000;
 
     protected string $host;
@@ -217,18 +217,33 @@ class Redis implements Connection
                 }
 
                 if ($attempt === self::CONNECT_MAX_ATTEMPTS) {
-                    throw $e;
+                    throw new \RedisException(
+                        \sprintf(
+                            'Failed to connect to Redis at %s:%d after %d attempts: %s',
+                            $this->host,
+                            $this->port,
+                            self::CONNECT_MAX_ATTEMPTS,
+                            $e->getMessage(),
+                        ),
+                        (int)$e->getCode(),
+                        $e,
+                    );
                 }
 
                 // Exponential backoff with full jitter to avoid thundering herd on recovery.
                 $backoffMs = \min(
                     self::CONNECT_MAX_BACKOFF_MS,
-                    self::CONNECT_BASE_BACKOFF_MS * (2 ** ($attempt - 1)),
+                    self::CONNECT_BACKOFF_MS * (2 ** ($attempt - 1)),
                 );
                 \usleep(\mt_rand(0, $backoffMs) * 1000);
             }
         }
 
-        throw new \RedisException('Unreachable: connect loop exited without success or exception.');
+        throw new \RedisException(\sprintf(
+            'Unreachable: Redis connect loop for %s:%d exited after %d attempts without success or exception.',
+            $this->host,
+            $this->port,
+            self::CONNECT_MAX_ATTEMPTS,
+        ));
     }
 }

--- a/src/Queue/Connection/Redis.php
+++ b/src/Queue/Connection/Redis.php
@@ -182,13 +182,8 @@ class Redis implements Connection
 
     public function close(): void
     {
-        try {
-            $this->redis?->close();
-        } catch (\Throwable) {
-            // best-effort: underlying socket may already be dead
-        } finally {
-            $this->redis = null;
-        }
+        $this->redis?->close();
+        $this->redis = null;
     }
 
     protected function getRedis(): \Redis
@@ -201,9 +196,11 @@ class Redis implements Connection
 
         for ($attempt = 1; $attempt <= self::CONNECT_MAX_ATTEMPTS; $attempt++) {
             $redis = new \Redis();
+            $connected = false;
 
             try {
                 $redis->connect($this->host, $this->port, $connectTimeout);
+                $connected = true;
 
                 if ($this->readTimeout >= 0) {
                     $redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->readTimeout);
@@ -212,6 +209,10 @@ class Redis implements Connection
                 $this->redis = $redis;
                 return $this->redis;
             } catch (\RedisException $e) {
+                if ($connected) {
+                    $redis->close();
+                }
+
                 if ($attempt === self::CONNECT_MAX_ATTEMPTS) {
                     throw $e;
                 }

--- a/src/Queue/Connection/Redis.php
+++ b/src/Queue/Connection/Redis.php
@@ -182,8 +182,12 @@ class Redis implements Connection
 
     public function close(): void
     {
-        $this->redis?->close();
-        $this->redis = null;
+        try {
+            $this->redis?->close();
+        } catch (\Throwable) {
+        } finally {
+            $this->redis = null;
+        }
     }
 
     protected function getRedis(): \Redis

--- a/src/Queue/Connection/Redis.php
+++ b/src/Queue/Connection/Redis.php
@@ -188,7 +188,7 @@ class Redis implements Connection
 
     protected function getRedis(): \Redis
     {
-        if ($this->redis instanceof \Redis) {
+        if ($this->redis) {
             return $this->redis;
         }
 

--- a/src/Queue/Connection/Redis.php
+++ b/src/Queue/Connection/Redis.php
@@ -210,7 +210,10 @@ class Redis implements Connection
                 return $this->redis;
             } catch (\RedisException $e) {
                 if ($connected) {
-                    $redis->close();
+                    try {
+                        $redis->close();
+                    } catch (\Throwable) {
+                    }
                 }
 
                 if ($attempt === self::CONNECT_MAX_ATTEMPTS) {

--- a/src/Queue/Connection/Redis.php
+++ b/src/Queue/Connection/Redis.php
@@ -6,6 +6,10 @@ use Utopia\Queue\Connection;
 
 class Redis implements Connection
 {
+    protected const int CONNECT_MAX_ATTEMPTS = 5;
+    protected const int CONNECT_BASE_BACKOFF_MS = 100;
+    protected const int CONNECT_MAX_BACKOFF_MS = 3_000;
+
     protected string $host;
     protected int $port;
     protected ?string $user;
@@ -178,25 +182,49 @@ class Redis implements Connection
 
     public function close(): void
     {
-        $this->redis?->close();
-        $this->redis = null;
+        try {
+            $this->redis?->close();
+        } catch (\Throwable) {
+            // best-effort: underlying socket may already be dead
+        } finally {
+            $this->redis = null;
+        }
     }
 
     protected function getRedis(): \Redis
     {
-        if ($this->redis) {
+        if ($this->redis instanceof \Redis) {
             return $this->redis;
         }
 
-        $this->redis = new \Redis();
-
         $connectTimeout = $this->connectTimeout < 0 ? 0 : $this->connectTimeout;
-        $this->redis->connect($this->host, $this->port, $connectTimeout);
 
-        if ($this->readTimeout >= 0) {
-            $this->redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->readTimeout);
+        for ($attempt = 1; $attempt <= self::CONNECT_MAX_ATTEMPTS; $attempt++) {
+            $redis = new \Redis();
+
+            try {
+                $redis->connect($this->host, $this->port, $connectTimeout);
+
+                if ($this->readTimeout >= 0) {
+                    $redis->setOption(\Redis::OPT_READ_TIMEOUT, $this->readTimeout);
+                }
+
+                $this->redis = $redis;
+                return $this->redis;
+            } catch (\RedisException $e) {
+                if ($attempt === self::CONNECT_MAX_ATTEMPTS) {
+                    throw $e;
+                }
+
+                // Exponential backoff with full jitter to avoid thundering herd on recovery.
+                $backoffMs = \min(
+                    self::CONNECT_MAX_BACKOFF_MS,
+                    self::CONNECT_BASE_BACKOFF_MS * (2 ** ($attempt - 1)),
+                );
+                \usleep(\mt_rand(0, $backoffMs) * 1000);
+            }
         }
 
-        return $this->redis;
+        throw new \RedisException('Unreachable: connect loop exited without success or exception.');
     }
 }

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -179,8 +179,12 @@ class RedisCluster implements Connection
 
     public function close(): void
     {
-        $this->redis?->close();
-        $this->redis = null;
+        try {
+            $this->redis?->close();
+        } catch (\Throwable) {
+        } finally {
+            $this->redis = null;
+        }
     }
 
     protected function getRedis(): \RedisCluster

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -179,13 +179,8 @@ class RedisCluster implements Connection
 
     public function close(): void
     {
-        try {
-            $this->redis?->close();
-        } catch (\Throwable) {
-            // best-effort: underlying socket may already be dead
-        } finally {
-            $this->redis = null;
-        }
+        $this->redis?->close();
+        $this->redis = null;
     }
 
     protected function getRedis(): \RedisCluster

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -6,6 +6,10 @@ use Utopia\Queue\Connection;
 
 class RedisCluster implements Connection
 {
+    protected const int CONNECT_MAX_ATTEMPTS = 5;
+    protected const int CONNECT_BASE_BACKOFF_MS = 100;
+    protected const int CONNECT_MAX_BACKOFF_MS = 3_000;
+
     protected array $seeds;
     protected float $connectTimeout;
     protected float $readTimeout;
@@ -175,19 +179,42 @@ class RedisCluster implements Connection
 
     public function close(): void
     {
-        $this->redis?->close();
-        $this->redis = null;
+        try {
+            $this->redis?->close();
+        } catch (\Throwable) {
+            // best-effort: underlying socket may already be dead
+        } finally {
+            $this->redis = null;
+        }
     }
 
     protected function getRedis(): \RedisCluster
     {
-        if ($this->redis) {
+        if ($this->redis instanceof \RedisCluster) {
             return $this->redis;
         }
 
         $connectTimeout = $this->connectTimeout < 0 ? 0 : $this->connectTimeout;
         $readTimeout = $this->readTimeout < 0 ? 0 : $this->readTimeout;
-        $this->redis = new \RedisCluster(null, $this->seeds, $connectTimeout, $readTimeout);
-        return $this->redis;
+
+        for ($attempt = 1; $attempt <= self::CONNECT_MAX_ATTEMPTS; $attempt++) {
+            try {
+                $this->redis = new \RedisCluster(null, $this->seeds, $connectTimeout, $readTimeout);
+                return $this->redis;
+            } catch (\RedisClusterException $e) {
+                if ($attempt === self::CONNECT_MAX_ATTEMPTS) {
+                    throw $e;
+                }
+
+                // Exponential backoff with full jitter to avoid thundering herd on recovery.
+                $backoffMs = \min(
+                    self::CONNECT_MAX_BACKOFF_MS,
+                    self::CONNECT_BASE_BACKOFF_MS * (2 ** ($attempt - 1)),
+                );
+                \usleep(\mt_rand(0, $backoffMs) * 1000);
+            }
+        }
+
+        throw new \RedisClusterException('Unreachable: connect loop exited without success or exception.');
     }
 }

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -185,7 +185,7 @@ class RedisCluster implements Connection
 
     protected function getRedis(): \RedisCluster
     {
-        if ($this->redis instanceof \RedisCluster) {
+        if ($this->redis) {
             return $this->redis;
         }
 

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -7,7 +7,7 @@ use Utopia\Queue\Connection;
 class RedisCluster implements Connection
 {
     protected const int CONNECT_MAX_ATTEMPTS = 5;
-    protected const int CONNECT_BASE_BACKOFF_MS = 100;
+    protected const int CONNECT_BACKOFF_MS = 100;
     protected const int CONNECT_MAX_BACKOFF_MS = 3_000;
 
     protected array $seeds;
@@ -198,18 +198,31 @@ class RedisCluster implements Connection
                 return $this->redis;
             } catch (\RedisClusterException $e) {
                 if ($attempt === self::CONNECT_MAX_ATTEMPTS) {
-                    throw $e;
+                    throw new \RedisClusterException(
+                        \sprintf(
+                            'Failed to connect to Redis cluster seeds [%s] after %d attempts: %s',
+                            \implode(', ', $this->seeds),
+                            self::CONNECT_MAX_ATTEMPTS,
+                            $e->getMessage(),
+                        ),
+                        (int)$e->getCode(),
+                        $e,
+                    );
                 }
 
                 // Exponential backoff with full jitter to avoid thundering herd on recovery.
                 $backoffMs = \min(
                     self::CONNECT_MAX_BACKOFF_MS,
-                    self::CONNECT_BASE_BACKOFF_MS * (2 ** ($attempt - 1)),
+                    self::CONNECT_BACKOFF_MS * (2 ** ($attempt - 1)),
                 );
                 \usleep(\mt_rand(0, $backoffMs) * 1000);
             }
         }
 
-        throw new \RedisClusterException('Unreachable: connect loop exited without success or exception.');
+        throw new \RedisClusterException(\sprintf(
+            'Unreachable: Redis cluster connect loop for seeds [%s] exited after %d attempts without success or exception.',
+            \implode(', ', $this->seeds),
+            self::CONNECT_MAX_ATTEMPTS,
+        ));
     }
 }

--- a/src/Queue/Connection/RedisCluster.php
+++ b/src/Queue/Connection/RedisCluster.php
@@ -200,7 +200,7 @@ class RedisCluster implements Connection
                 if ($attempt === self::CONNECT_MAX_ATTEMPTS) {
                     throw new \RedisClusterException(
                         \sprintf(
-                            'Failed to connect to Redis cluster seeds [%s] after %d attempts: %s',
+                            'Failed to connect to Redis cluster nodes [%s] after %d attempts: %s',
                             \implode(', ', $this->seeds),
                             self::CONNECT_MAX_ATTEMPTS,
                             $e->getMessage(),
@@ -220,7 +220,7 @@ class RedisCluster implements Connection
         }
 
         throw new \RedisClusterException(\sprintf(
-            'Unreachable: Redis cluster connect loop for seeds [%s] exited after %d attempts without success or exception.',
+            'Unreachable: Redis cluster connect loop for nodes [%s] exited after %d attempts without success or exception.',
             \implode(', ', $this->seeds),
             self::CONNECT_MAX_ATTEMPTS,
         ));

--- a/tests/Queue/E2E/Adapter/RedisReconnectCallbackTest.php
+++ b/tests/Queue/E2E/Adapter/RedisReconnectCallbackTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\E2E\Adapter;
+
+use PHPUnit\Framework\TestCase;
+use Utopia\Queue\Broker\Redis as RedisBroker;
+use Utopia\Queue\Connection;
+use Utopia\Queue\Queue;
+
+class RedisReconnectCallbackTest extends TestCase
+{
+    public function testReconnectCallbackReceivesAttemptContext(): void
+    {
+        $queue = new Queue('reconnect-callback');
+        $connection = new FailingRedisConnection();
+        $broker = new RedisBroker($connection);
+        $calls = [];
+
+        $broker->setReconnectCallback(function (Queue $queue, \Throwable $error, int $attempt, int $sleepMs) use (&$calls, $broker): void {
+            $calls[] = [
+                'queue' => $queue,
+                'error' => $error,
+                'attempt' => $attempt,
+                'sleepMs' => $sleepMs,
+            ];
+
+            $broker->close();
+        });
+
+        $broker->consume(
+            $queue,
+            fn () => null,
+            fn () => null,
+            fn () => null,
+        );
+
+        $this->assertSame(1, $connection->popAttempts);
+        $this->assertCount(1, $calls);
+        $this->assertSame($queue, $calls[0]['queue']);
+        $this->assertInstanceOf(\RedisException::class, $calls[0]['error']);
+        $this->assertSame(1, $calls[0]['attempt']);
+        $this->assertIsInt($calls[0]['sleepMs']);
+        $this->assertGreaterThanOrEqual(0, $calls[0]['sleepMs']);
+        $this->assertLessThanOrEqual(100, $calls[0]['sleepMs']);
+    }
+}
+
+class FailingRedisConnection implements Connection
+{
+    public int $popAttempts = 0;
+
+    public function rightPushArray(string $queue, array $payload): bool
+    {
+        return true;
+    }
+
+    public function rightPopArray(string $queue, int $timeout): array|false
+    {
+        $this->popAttempts++;
+
+        throw new \RedisException('Redis is unavailable.');
+    }
+
+    public function rightPopLeftPushArray(string $queue, string $destination, int $timeout): array|false
+    {
+        return false;
+    }
+
+    public function leftPushArray(string $queue, array $payload): bool
+    {
+        return true;
+    }
+
+    public function leftPopArray(string $queue, int $timeout): array|false
+    {
+        return false;
+    }
+
+    public function rightPush(string $queue, string $payload): bool
+    {
+        return true;
+    }
+
+    public function rightPop(string $queue, int $timeout): string|false
+    {
+        return false;
+    }
+
+    public function rightPopLeftPush(string $queue, string $destination, int $timeout): string|false
+    {
+        return false;
+    }
+
+    public function leftPush(string $queue, string $payload): bool
+    {
+        return true;
+    }
+
+    public function leftPop(string $queue, int $timeout): string|false
+    {
+        return false;
+    }
+
+    public function listRemove(string $queue, string $key): bool
+    {
+        return true;
+    }
+
+    public function listSize(string $key): int
+    {
+        return 0;
+    }
+
+    public function listRange(string $key, int $total, int $offset): array
+    {
+        return [];
+    }
+
+    public function remove(string $key): bool
+    {
+        return true;
+    }
+
+    public function move(string $queue, string $destination): bool
+    {
+        return true;
+    }
+
+    public function set(string $key, string $value, int $ttl = 0): bool
+    {
+        return true;
+    }
+
+    public function get(string $key): array|string|null
+    {
+        return null;
+    }
+
+    public function setArray(string $key, array $value, int $ttl = 0): bool
+    {
+        return true;
+    }
+
+    public function increment(string $key): int
+    {
+        return 1;
+    }
+
+    public function decrement(string $key): int
+    {
+        return 0;
+    }
+
+    public function ping(): bool
+    {
+        return false;
+    }
+
+    public function close(): void
+    {
+    }
+}

--- a/tests/Queue/E2E/Adapter/RedisReconnectCallbackTest.php
+++ b/tests/Queue/E2E/Adapter/RedisReconnectCallbackTest.php
@@ -43,6 +43,36 @@ class RedisReconnectCallbackTest extends TestCase
         $this->assertGreaterThanOrEqual(0, $calls[0]['sleepMs']);
         $this->assertLessThanOrEqual(100, $calls[0]['sleepMs']);
     }
+
+    public function testReconnectSuccessCallbackReceivesAttemptCount(): void
+    {
+        $queue = new Queue('reconnect-success-callback');
+        $connection = new RecoveringRedisConnection();
+        $broker = new RedisBroker($connection);
+        $calls = [];
+
+        $broker->setReconnectCallback(fn () => null);
+        $broker->setReconnectSuccessCallback(function (Queue $queue, int $attempts) use (&$calls, $broker): void {
+            $calls[] = [
+                'queue' => $queue,
+                'attempts' => $attempts,
+            ];
+
+            $broker->close();
+        });
+
+        $broker->consume(
+            $queue,
+            fn () => null,
+            fn () => null,
+            fn () => null,
+        );
+
+        $this->assertSame(2, $connection->popAttempts);
+        $this->assertCount(1, $calls);
+        $this->assertSame($queue, $calls[0]['queue']);
+        $this->assertSame(1, $calls[0]['attempts']);
+    }
 }
 
 class FailingRedisConnection implements Connection
@@ -158,5 +188,19 @@ class FailingRedisConnection implements Connection
 
     public function close(): void
     {
+    }
+}
+
+class RecoveringRedisConnection extends FailingRedisConnection
+{
+    public function rightPopArray(string $queue, int $timeout): array|false
+    {
+        $this->popAttempts++;
+
+        if ($this->popAttempts === 1) {
+            throw new \RedisException('Redis is unavailable.');
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## Summary

Harden the Redis broker and connection adapters so workers survive transient Redis outages (DNS flaps, failover, restarts, brief network partitions) instead of crash-looping under a supervisor.

- **Connection layer** (`Connection/Redis.php`, `Connection/RedisCluster.php`): lazy `getRedis()` now retries up to 5 attempts with exponential backoff + full jitter (100 ms base, 3 s cap) before throwing. `close()` is best-effort and always clears the cached handle.
- **Broker** (`Broker/Redis.php`): `consume()` catches `RedisException` and `RedisClusterException` raised by the blocking pop, drops the stale connection without letting close failures mask the original reconnect path, applies capped backoff with full jitter (100 ms base, 5 s cap), and continues. Backoff resets on the first successful pop.

## Motivation

Before this change, a single Redis exception during `brPop` would bubble out of `consume()` and kill the worker process. Any transient Redis issue — failover, restart, brief network partition — caused the worker fleet to rely on the process supervisor for recovery, which can reopen many connections at the same instant and create a thundering herd on the recovering Redis.

Similarly, `getRedis()` opened a single socket with no retry, so a one-off DNS or TCP hiccup during boot surfaced as an unrecoverable failure to the caller.

## What changed

### `src/Queue/Connection/Redis.php`
- Added `CONNECT_MAX_ATTEMPTS` (5), `CONNECT_BACKOFF_MS` (100), `CONNECT_MAX_BACKOFF_MS` (3 000) constants.
- `getRedis()` wraps `new \\Redis()` + `connect()` + `setOption()` in a retry loop. On failure it throws a `\\RedisException` with host, port, attempt count, and the original exception as `previous`. `close()` wraps phpredis close in `try/finally` so stale handles are always cleared.
- If setup fails after a socket was opened, the temporary Redis instance is closed before retrying so failed `setOption()` attempts do not leak sockets.

### `src/Queue/Connection/RedisCluster.php`
- Added the same retry constants and a retry loop around `new \\RedisCluster(...)`, catching `\\RedisClusterException`. On failure it throws a `\\RedisClusterException` with cluster node list, attempt count, and the original exception as `previous`. `close()` wraps phpredis close in `try/finally` so stale handles are always cleared.

### `src/Queue/Broker/Redis.php`
- Added `RECONNECT_BACKOFF_MS` (100) and `RECONNECT_MAX_BACKOFF_MS` (5 000) constants.
- `consume()` catches `\\RedisException|\\RedisClusterException` from the blocking pop. If the broker was closed, it exits cleanly. Otherwise it drops the stale connection, sleeps for `mt_rand(0, backoffMs)` (full jitter), and continues the loop.
- The broker backoff is maintained as a capped delay value instead of an ever-growing exponent.
- Backoff resets to the base delay after any successful pop.

## Swoole considerations

The `usleep()` calls cooperate with the Swoole reactor because `src/Queue/Adapter/Swoole.php:37` sets `SWOOLE_HOOK_ALL`, which hooks `usleep` to `Coroutine::sleep`. If that flag is ever narrowed, these sleeps will block the reactor.

## Design notes

- **Full jitter** is used because the realistic failure mode is all workers losing the connection simultaneously; full jitter spreads reconnect attempts during recovery.
- **Broker retries unbounded.** There is no max-attempt ceiling in `consume()` — a worker should stay alive across arbitrarily long outages. Operators rely on `closed=true` from `close()` to end the loop.
- **Caught types are phpredis exceptions** in the broker, which is an abstraction leak but consistent with the existing Redis-specific broker and adapters. Translating to a neutral `ConnectionException` is out of scope here.

## Test plan

- [x] `composer lint`
- [x] `vendor/bin/phpstan analyse --memory-limit=1G`
- [x] GitHub Actions adapter tests
- [x] Greptile review

## Out of scope / follow-ups

- `Connection\\Redis` constructor accepts `$user`/`$password` but `getRedis()` never calls `auth()`. Pre-existing bug; worth a separate PR.
- Telemetry hook or log on reconnect — operators currently get no signal when a worker enters the retry loop. Candidate for a follow-up using `utopia-php/telemetry`.
- Translate phpredis exceptions into a driver-neutral `ConnectionException` so the broker stops depending on phpredis exception types directly.
- Promote `CONNECT_MAX_ATTEMPTS` etc. to constructor parameters if operators want to tune them per deployment.