### PR TITLE
Remove fetch dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "php-amqplib/php-amqplib": "^3.7",
         "utopia-php/di": "0.3.*",
         "utopia-php/servers": "0.3.*",
-        "utopia-php/fetch": "0.5.*",
         "utopia-php/pools": "1.*",
         "utopia-php/telemetry": "0.2.*",
         "utopia-php/validators": "0.2.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5787da320be70add7a7ef3673f31039",
+    "content-hash": "a933d8be6a14606507c5dca6aa0b8cec",
     "packages": [
         {
             "name": "brick/math",
@@ -2230,45 +2230,6 @@
                 "source": "https://github.com/utopia-php/di/tree/0.3.1"
             },
             "time": "2026-03-13T05:47:23+00:00"
-        },
-        {
-            "name": "utopia-php/fetch",
-            "version": "0.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/utopia-php/fetch.git",
-                "reference": "a96a010e1c273f3888765449687baf58cbc61fcd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/fetch/zipball/a96a010e1c273f3888765449687baf58cbc61fcd",
-                "reference": "a96a010e1c273f3888765449687baf58cbc61fcd",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.5.0",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Utopia\\Fetch\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A simple library that provides an interface for making HTTP Requests.",
-            "support": {
-                "issues": "https://github.com/utopia-php/fetch/issues",
-                "source": "https://github.com/utopia-php/fetch/tree/0.5.1"
-            },
-            "time": "2025-12-18T16:25:10+00:00"
         },
         {
             "name": "utopia-php/pools",

--- a/src/Queue/Broker/AMQP.php
+++ b/src/Queue/Broker/AMQP.php
@@ -6,9 +6,9 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Exchange\AMQPExchangeType;
+use PhpAmqpLib\Exception\AMQPProtocolChannelException;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
-use Utopia\Fetch\Client;
 use Utopia\Queue\Consumer;
 use Utopia\Queue\Error\Retryable;
 use Utopia\Queue\Message;
@@ -165,21 +165,21 @@ class AMQP implements Publisher, Consumer
             $queueName = $queueName . '.failed';
         }
 
-        $client = new Client();
-        $response = $client->fetch(sprintf('http://%s:%s@%s:%s/api/queues/%s/%s', $this->user, $this->password, $this->host, $this->httpPort, urlencode($this->vhost), $queueName));
+        $messageCount = 0;
+        $this->withChannel(function (AMQPChannel $channel) use ($queueName, &$messageCount) {
+            try {
+                [, $messageCount] = $channel->queue_declare($queueName, passive: true);
+            } catch (AMQPProtocolChannelException $e) {
+                $this->channel = null;
+                if ($e->getCode() === 404) {
+                    return;
+                }
 
-        // If this queue does not exist (yet), the queue size is 0.
-        if ($response->getStatusCode() === 404) {
-            return 0;
-        }
+                throw $e;
+            }
+        });
 
-        if ($response->getStatusCode() !== 200) {
-            throw new \Exception(sprintf('Invalid status code %d: %s', $response->getStatusCode(), $response->getBody()));
-        }
-
-        $data = $response->json();
-
-        return $data['messages'] ?? 0;
+        return $messageCount;
     }
 
     /**


### PR DESCRIPTION
## Summary

- remove the runtime `utopia-php/fetch` dependency from Queue
- replace the RabbitMQ management HTTP API queue-size lookup with AMQP `queue_declare(..., passive: true)`
- keep missing queues returning `0`, matching the previous HTTP 404 behavior

## Context

`utopia-php/fetch` was only used in `src/Queue/Broker/AMQP.php` to call RabbitMQ's HTTP management API from `getQueueSize()`.

RabbitMQ already returns the queue depth in the AMQP `queue.declare-ok` response as `message_count`, so the broker can get queue size through its existing AMQP channel instead of requiring the HTTP management plugin and an extra HTTP client dependency.

A passive declare closes the channel when the queue does not exist, so the implementation catches RabbitMQ's 404 channel exception, clears the cached channel, and returns `0` to preserve the old behavior.

## Test Plan

- `php -l src/Queue/Broker/AMQP.php`
- `composer validate --no-check-publish`
- `vendor/bin/pint --test`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=512M`
