### PR TITLE
Relax servers patch constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": ">=8.3",
         "php-amqplib/php-amqplib": "^3.7",
         "utopia-php/di": "0.3.*",
-        "utopia-php/servers": "0.4.0",
+        "utopia-php/servers": "0.4.*",
         "utopia-php/pools": "1.*",
         "utopia-php/telemetry": "0.2.*",
         "utopia-php/validators": "0.2.*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea4ee3f36e2ca271c2bd33a5f5b48dbc",
+    "content-hash": "5d9941e9b20a90ae4e6170f6de617073",
     "packages": [
         {
             "name": "brick/math",
@@ -2283,16 +2283,16 @@
         },
         {
             "name": "utopia-php/servers",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/servers.git",
-                "reference": "7db346ef377503efe0acafe0791085270cd9ed70"
+                "reference": "6e9241f587a19c0e9e7a3587fe3b15ffb2d4c2a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/servers/zipball/7db346ef377503efe0acafe0791085270cd9ed70",
-                "reference": "7db346ef377503efe0acafe0791085270cd9ed70",
+                "url": "https://api.github.com/repos/utopia-php/servers/zipball/6e9241f587a19c0e9e7a3587fe3b15ffb2d4c2a4",
+                "reference": "6e9241f587a19c0e9e7a3587fe3b15ffb2d4c2a4",
                 "shasum": ""
             },
             "require": {
@@ -2331,9 +2331,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/servers/issues",
-                "source": "https://github.com/utopia-php/servers/tree/0.4.0"
+                "source": "https://github.com/utopia-php/servers/tree/0.4.1"
             },
-            "time": "2026-05-05T04:08:30+00:00"
+            "time": "2026-05-21T13:08:45+00:00"
         },
         {
             "name": "utopia-php/telemetry",


### PR DESCRIPTION
## What

- Relax `utopia-php/servers` from an exact `0.4.0` pin to `0.4.*`.
- Update `composer.lock` to resolve `utopia-php/servers` `0.4.1`.

## Why

`utopia-php/servers` has a `0.4.1` patch release, but downstream consumers cannot install it while this package requires `0.4.0` exactly. Allowing the `0.4.*` patch line keeps compatibility constrained to the current minor while unblocking patch updates.

## Validation

- `composer update utopia-php/servers --ignore-platform-reqs`
- `composer validate --strict --no-check-publish`
