### PR TITLE
Update telemetry dependency constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "utopia-php/lock": "0.2.*",
         "utopia-php/servers": "0.4.*",
         "utopia-php/pools": "1.*",
-        "utopia-php/telemetry": "0.4.*",
+        "utopia-php/telemetry": "^0.4",
         "utopia-php/validators": "0.2.*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1d5f6649fb727b85e109128125f7ff9d",
+    "content-hash": "b5f6df61ae8bf4786a05013ae1b957e5",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
## Summary
- Relax `utopia-php/telemetry` from `0.4.*` to `^0.4`.
- Refresh `composer.lock` content hash for the root constraint change.

## Why
Circuit breaker `0.3.1` uses the telemetry `0.4` lazy metric API. Keeping Utopia libraries on narrow telemetry constraints makes dependency alignment harder across the Appwrite stack.

## Tests
- `composer validate --strict`
- `composer lint`
- `composer test` (fails in local environment because `amqp:5672` is not resolvable)
