### PR TITLE
chore(deps): allow utopia-php/lock 0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "php": ">=8.5",
         "utopia-php/di": "^0.3",
-        "utopia-php/lock": "^0.2",
+        "utopia-php/lock": "0.3.*",
         "utopia-php/servers": "^0.4",
         "utopia-php/pools": "^2.0",
         "utopia-php/telemetry": "^0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9ff7e8f7edf164cb1079d409a8df46f",
+    "content-hash": "b96a8c054cd4f5eb0ca5dacdf2be877b",
     "packages": [
         {
             "name": "brick/math",
@@ -1927,16 +1927,16 @@
         },
         {
             "name": "utopia-php/lock",
-            "version": "0.2.3",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/lock.git",
-                "reference": "4eca3784d4c112655faf77adcf0fdbb186650487"
+                "reference": "ee39f161b79f79d6959b8f8c9502376b4e6f8575"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/lock/zipball/4eca3784d4c112655faf77adcf0fdbb186650487",
-                "reference": "4eca3784d4c112655faf77adcf0fdbb186650487",
+                "url": "https://api.github.com/repos/utopia-php/lock/zipball/ee39f161b79f79d6959b8f8c9502376b4e6f8575",
+                "reference": "ee39f161b79f79d6959b8f8c9502376b4e6f8575",
                 "shasum": ""
             },
             "require": {
@@ -1969,9 +1969,9 @@
             "description": "A simple lock library to coordinate access to shared resources across coroutines, processes and hosts",
             "support": {
                 "issues": "https://github.com/utopia-php/lock/issues",
-                "source": "https://github.com/utopia-php/lock/tree/0.2.3"
+                "source": "https://github.com/utopia-php/lock/tree/0.3.0"
             },
-            "time": "2026-06-26T10:48:18+00:00"
+            "time": "2026-08-12T06:54:16+00:00"
         },
         {
             "name": "utopia-php/pools",
@@ -2031,22 +2031,22 @@
         },
         {
             "name": "utopia-php/servers",
-            "version": "0.4.6",
+            "version": "0.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/servers.git",
-                "reference": "036c4da1c8b9a5bba1a973270158ba745a5944c9"
+                "reference": "18572544b1da5af415e5abbd59ba00af29e37de7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/servers/zipball/036c4da1c8b9a5bba1a973270158ba745a5944c9",
-                "reference": "036c4da1c8b9a5bba1a973270158ba745a5944c9",
+                "url": "https://api.github.com/repos/utopia-php/servers/zipball/18572544b1da5af415e5abbd59ba00af29e37de7",
+                "reference": "18572544b1da5af415e5abbd59ba00af29e37de7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.5",
                 "utopia-php/di": "^0.3",
-                "utopia-php/validators": "0.3.*"
+                "utopia-php/validators": "^0.4"
             },
             "type": "library",
             "autoload": {
@@ -2074,9 +2074,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/servers/issues",
-                "source": "https://github.com/utopia-php/servers/tree/0.4.6"
+                "source": "https://github.com/utopia-php/servers/tree/0.4.7"
             },
-            "time": "2026-07-13T11:15:40+00:00"
+            "time": "2026-08-10T04:51:03+00:00"
         },
         {
             "name": "utopia-php/telemetry",
@@ -2131,16 +2131,16 @@
         },
         {
             "name": "utopia-php/validators",
-            "version": "0.3.1",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/utopia-php/validators.git",
-                "reference": "d9c2269ebd2596a09681ccd2fd133eeedfcdf9ba"
+                "reference": "a5b7b78b789e5af0a30f96da8355bbf48fb56699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/utopia-php/validators/zipball/d9c2269ebd2596a09681ccd2fd133eeedfcdf9ba",
-                "reference": "d9c2269ebd2596a09681ccd2fd133eeedfcdf9ba",
+                "url": "https://api.github.com/repos/utopia-php/validators/zipball/a5b7b78b789e5af0a30f96da8355bbf48fb56699",
+                "reference": "a5b7b78b789e5af0a30f96da8355bbf48fb56699",
                 "shasum": ""
             },
             "require": {
@@ -2165,9 +2165,9 @@
             ],
             "support": {
                 "issues": "https://github.com/utopia-php/validators/issues",
-                "source": "https://github.com/utopia-php/validators/tree/0.3.1"
+                "source": "https://github.com/utopia-php/validators/tree/0.4.2"
             },
-            "time": "2026-07-14T11:55:48+00:00"
+            "time": "2026-08-11T07:43:49+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
## Why

`utopia-php/lock` 0.3.0 adds `DistributedLock::adopt()`, which lets a holder delegate token-guarded commands such as `refresh()` to an instance backed by a **different Redis connection**.

appwrite/cloud needs it to close a live production defect: its lock refresher coroutine currently shares the action's borrowed Redis connection with the action itself, so two coroutines command one socket. The result is a Swoole fatal that takes the worker process down with every in-flight message already popped, which has meant acknowledged deletes that tore nothing down and left compute running and billing.

Composer resolves the **intersection** of every constraint on a package, so cloud cannot reach 0.3.0 while anything in its tree pins `^0.2`. Three do: cloud's root, `appwrite/server-ce`, and this package. This is the first of the three.

## Why it is safe

lock 0.3.0 is purely additive over 0.2.4: `git diff 0.2.4 0.3.0` is 123 insertions and 0 deletions across `README.md`, `src/Distributed.php` and `tests/DistributedTest.php`. The only functional change is the new `adopt()` method. No signature or behaviour change to anything that existed.

This package uses only `Utopia\Lock\Lock` and `Utopia\Lock\Mutex` (`src/Queue/Connection/Locking.php:5-6`). It does not touch `Distributed` at all, so the added method is invisible here.

## The lock file refresh

`composer.lock` on `main` could not resolve as committed, independently of this change:

```
Root composer.json requires utopia-php/validators ^0.4
utopia-php/servers 0.4.6 requires utopia-php/validators 0.3.*
```

`servers` was pinned at 0.4.6 in the lock while the root already allowed `^0.4`, and `servers` 0.4.7 requires `validators ^0.4`. So the lock only needed refreshing to become resolvable. Exactly three packages move:

| Package | Before | After |
| --- | --- | --- |
| `utopia-php/lock` | 0.2.3 | 0.3.0 |
| `utopia-php/servers` | 0.4.6 | 0.4.7 |
| `utopia-php/validators` | 0.3.1 | 0.4.2 |

`validators` 0.3 to 0.4 is additive for this package's purposes: 0.4.0 adds a phone validator, 0.4.1 is a no-op re-release, 0.4.2 makes `Identifier` reject a trailing newline. This package's only use is an `instanceof Validator` check at `src/Queue/Server.php:460`.

## Verification

```
composer validate --no-check-publish
./composer.json is valid

composer update utopia-php/lock utopia-php/servers utopia-php/validators -W
No security vulnerability advisories found.
```

`vendor/bin/pint` is not installed in this package, so linting is whatever CI provides. I did not run the Tests job locally: it needs the Redis and Swoole services from CI, and the standing rule here is to report what was observed rather than imply a pass. CI is the gate.